### PR TITLE
fix: new webdocs not showing (#36)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Build sdist and wheel
         run: pipx run build
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           path: dist
 
@@ -47,7 +47,7 @@ jobs:
     if: github.event_name == 'release' && github.event.action == 'published'
 
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: artifact
           path: dist


### PR DESCRIPTION
* build(deps): bump actions/download-artifact from 3 to 4 (#34)

Bumps [actions/download-artifact](https://github.com/actions/download-artifact) from 3 to 4.
- [Release notes](https://github.com/actions/download-artifact/releases)
- [Commits](https://github.com/actions/download-artifact/compare/v3...v4)

---
updated-dependencies:
- dependency-name: actions/download-artifact dependency-type: direct:production update-type: version-update:semver-major ...




* build(deps): bump actions/upload-artifact from 3 to 4 (#35)

Bumps [actions/upload-artifact](https://github.com/actions/upload-artifact) from 3 to 4.
- [Release notes](https://github.com/actions/upload-artifact/releases)
- [Commits](https://github.com/actions/upload-artifact/compare/v3...v4)

---
updated-dependencies:
- dependency-name: actions/upload-artifact dependency-type: direct:production update-type: version-update:semver-major ...




* chore: write readthedocs page (#24)

* saving progress

* progress...

* automatically generated docstrings

* Docs generating correctly, still need tutorials but otherwise okay.

* excluding docs from ruff

* restructured files again, got website working

* update init

* updating init

---------